### PR TITLE
don't return (undef) from getCustomerProfileIds

### DIFF
--- a/lib/Business/AuthorizeNet/CIM.pm
+++ b/lib/Business/AuthorizeNet/CIM.pm
@@ -733,7 +733,10 @@ sub getCustomerProfileIds {
 
     my $d = XMLin($resp->content, SuppressEmpty => '');
     my $id_num = $d->{ids}->{numericString};
-    my @ids = ref($id_num) eq 'ARRAY' ? @$id_num : ($id_num);
+    my @ids = ref($id_num) eq 'ARRAY' ? @$id_num
+            : defined $id_num         ? ($id_num)
+            :                           ();
+
     return @ids;
 }
 


### PR DESCRIPTION
When there are 0 profiles, getCustomerProfileIds returns a one-element list with (undef) in it.  This makes the code in the synopsis die.

If there are no ideas, the return value should be an empty list.
