### PR TITLE
Fix RT 80389: properly generate xml for multiple lineItems in a transaction

### DIFF
--- a/lib/Business/AuthorizeNet/CIM.pm
+++ b/lib/Business/AuthorizeNet/CIM.pm
@@ -557,14 +557,14 @@ sub createCustomerProfileTransaction {
     # lineItems
     if (exists $args->{lineItems}) {
         my @lineItems = (ref($args->{lineItems}) eq 'ARRAY') ? @{$args->{lineItems}} : ($args->{lineItems});
-        $writer->startTag('lineItems');
         foreach my $lineItem (@lineItems) {
+            $writer->startTag('lineItems');
             foreach my $k ('itemId', 'name', 'description', 'quantity', 'unitPrice', 'taxable') {
                 $writer->dataElement($k, $lineItem->{$k})
                     if exists $lineItem->{$k};
             }
+            $writer->endTag('lineItems');
         }
-        $writer->endTag('lineItems');
     }
 
     $writer->dataElement('customerProfileId', $args->{customerProfileId});


### PR DESCRIPTION
Hi fayland,

This is a fix for the bug report in RT#80389 (https://rt.cpan.org/Public/Bug/Display.html?id=80389). It bit me today (and actually saved my ass, because I accidentally had duplicate items).

Thanks!
rhesa
