### PR TITLE
allow optional customerProfileId

### DIFF
--- a/lib/Business/AuthorizeNet/CIM.pm
+++ b/lib/Business/AuthorizeNet/CIM.pm
@@ -573,7 +573,8 @@ sub createCustomerProfileTransaction {
         }
     }
 
-    $writer->dataElement('customerProfileId', $args->{customerProfileId});
+    $writer->dataElement('customerProfileId', $args->{customerProfileId})
+        if $args->{customerProfileId};
     $writer->dataElement('customerPaymentProfileId', $args->{customerPaymentProfileId}) 
         if $args->{customerPaymentProfileId};
     $writer->dataElement('customerShippingAddressId', $args->{customerShippingAddressId})


### PR DESCRIPTION
Allow optional customerProfileId in createCustomerProfileTransaction
(used in refund scenarios on non CIM transactions).