### PR TITLE
Add support for more generic arguments to getCustomerPaymentProfileRequest

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl extension Business-AuthorizeNet-CIM
 
+0.17    2018-07-11
+        add support for multiple optional fields being passed to
+        getCustomerPaymentProfileRequest, instead of only allowing
+        unmaskExpirationDate (ricecake)
+
 0.16    2017-06-26
         no code changes
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Business-AuthorizeNet-CIM
-version = 0.16
+version = 0.17
 author = Fayland Lam <fayland@gmail.com>
 author = Rhesa Rozendaal
 author = Olaf Alders

--- a/lib/Business/AuthorizeNet/CIM.pm
+++ b/lib/Business/AuthorizeNet/CIM.pm
@@ -793,7 +793,7 @@ sub getCustomerPaymentProfileRequest {
         # we want to act as though we were passed the legacy boolean flag for setting
         # 'unmaskExpirationDate' directly.
         if (ref($args) eq 'HASH') {
-            for my $dataElement (keys %$args) {
+            for my $dataElement (grep {exists $args->{$_}} qw(unmaskExpirationDate includeIssuerInfo)) {
                 $writer->dataElement($dataElement, $args->{$dataElement});
             }
         }

--- a/lib/Business/AuthorizeNet/CIM.pm
+++ b/lib/Business/AuthorizeNet/CIM.pm
@@ -789,8 +789,16 @@ sub getCustomerPaymentProfileRequest {
     $writer->dataElement('customerProfileId', $customerProfileId);
     $writer->dataElement('customerPaymentProfileId', $customerPaymentProfileId);
     if ($args) {
-        for my $dataElement (keys %$args) {
-            $writer->dataElement($dataElement, $args->{$dataElement});
+        # for backwards compatability, if a true non-hash value is passed through
+        # we want to act as though we were passed the legacy boolean flag for setting
+        # 'unmaskExpirationDate' directly.
+        if (ref($args) eq 'HASH') {
+            for my $dataElement (keys %$args) {
+                $writer->dataElement($dataElement, $args->{$dataElement});
+            }
+        }
+        else {
+            $writer->dataElement('unmaskExpirationDate', 'true');
         }
     }
     $writer->endTag('getCustomerPaymentProfileRequest');

--- a/lib/Business/AuthorizeNet/CIM.pm
+++ b/lib/Business/AuthorizeNet/CIM.pm
@@ -766,15 +766,18 @@ sub getCustomerProfile {
 
 =head3 getCustomerPaymentProfileRequest
 
-Retrieve a customer payment profile for an existing customer profile. $unmaskExpirationDate is an optional boolean arg, if passed
-a true value it will return the expiration date in YYYY-MM format, else it will mask as XXXX.
+Retrieve a customer payment profile for an existing customer profile. Optionally, a hash
+reference of additonal arguments may be passed in, and will be added to the request.
 
-    $cim->getCustomerPaymentProfileRequest($customerProfileId, $customerPaymentProfileId, $unmaskExpirationDate);
+    $cim->getCustomerPaymentProfileRequest($customerProfileId, $customerPaymentProfileId, {
+        includeIssuerInfo    => 'true',
+        unmaskExpirationDate => 'true',
+    });
 
 =cut
 
 sub getCustomerPaymentProfileRequest {
-    my ($self, $customerProfileId, $customerPaymentProfileId, $unmaskExpirationDate) = @_;
+    my ($self, $customerProfileId, $customerPaymentProfileId, $args) = @_;
 
     my $xml;
     my $writer = XML::Writer->new(OUTPUT => \$xml);
@@ -785,7 +788,11 @@ sub getCustomerPaymentProfileRequest {
     $writer->endTag('merchantAuthentication');
     $writer->dataElement('customerProfileId', $customerProfileId);
     $writer->dataElement('customerPaymentProfileId', $customerPaymentProfileId);
-    $writer->dataElement('unmaskExpirationDate', 'true') if $unmaskExpirationDate;
+    if ($args) {
+        for my $dataElement (keys %$args) {
+            $writer->dataElement($dataElement, $args->{$dataElement});
+        }
+    }
     $writer->endTag('getCustomerPaymentProfileRequest');
 
     return $self->_send($xml);


### PR DESCRIPTION
Add the capability to pass generic arguments to getCustomerPaymentProfileRequest by converting the boolean parameter for unmaskExpirationDate into a hash which will be added to the call.